### PR TITLE
Multi fields

### DIFF
--- a/beetsplug/summarize.py
+++ b/beetsplug/summarize.py
@@ -120,22 +120,22 @@ def set_str_converter(stat, stat_type):
 
 def group_by(category: str, items):
     """Group a list of items by a category.
-    
+
     If the category is one that supports multiple values, split them by ";" and add
     the item to each of the groups.
     """
-    MULTIPLE_FIELDS = ["albumartist", "artist", "genre"]
-    
+    multifield_categories = ["albumartist", "artist", "genre"]
+
     out = {}
     for item in items:
         cat = getattr(item, category)
-        if category in MULTIPLE_FIELDS:
+        if category in multifield_categories:
             cats = [c.strip() for c in cat.split(";")]
         else:
             cats = [cat]
 
         for cat in cats:
-            
+
             if cat not in out:
                 out[cat] = []
 

--- a/beetsplug/summarize.py
+++ b/beetsplug/summarize.py
@@ -118,16 +118,28 @@ def set_str_converter(stat, stat_type):
         stat["str_converter"] = "len"
 
 
-def group_by(category, items):
-    """Group a list of items by a category."""
+def group_by(category: str, items):
+    """Group a list of items by a category.
+    
+    If the category is one that supports multiple values, split them by ";" and add
+    the item to each of the groups.
+    """
+    MULTIPLE_FIELDS = ["albumartist", "artist", "genre"]
+    
     out = {}
     for item in items:
         cat = getattr(item, category)
+        if category in MULTIPLE_FIELDS:
+            cats = [c.strip() for c in cat.split(";")]
+        else:
+            cats = [cat]
 
-        if cat not in out:
-            out[cat] = []
+        for cat in cats:
+            
+            if cat not in out:
+                out[cat] = []
 
-        out[cat].append(item)
+            out[cat].append(item)
 
     return out
 

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -34,6 +34,17 @@ def lib():
     lib.add(MockItem("song1", 2000, "artist1", "album1", 128, "lyrics1"))
     lib.add(MockItem("song2", 2001, "artist2", "album2", 256, "lyrics2"))
     lib.add(MockItem("song3", 2002, "artist3", "album3", 512, "lyrics3"))
+    lib.add(
+        MockItem(
+            "song4",
+            2003,
+            "artist3; artist4",
+            "album4",
+            700,
+            "so many lyrics in this song",
+        )
+    )
+
     return lib
 
 
@@ -78,3 +89,13 @@ def test_show_summary(lib):
     assert "2000 |" in txt
     assert "2001 |" in txt
     assert "2002 |" in txt
+
+
+def test_show_summary_artist(lib):
+    stats = "count"
+    txt = sm.show_summary(lib, "query", category="artist", stats=stats, reverse=False)
+
+    assert "artist1 | 1" in txt
+    assert "artist2 | 1" in txt
+    assert "artist3 | 2" in txt  # in the multi-field
+    assert "artist4 | 1" in txt  # in the multi-field


### PR DESCRIPTION
Fixes #37 

Allows some fields to be multi-field capable, separated by ';'. In this case, the track gets added to *each* group.

## Summary by Sourcery

Bug Fixes:
- Fix a bug where tracks were only added to the first group when using multi-field values for grouping.